### PR TITLE
Fix out_modify_stack

### DIFF
--- a/dynstack/include/dynstack/stack/wrapper/out_modify_stack.h
+++ b/dynstack/include/dynstack/stack/wrapper/out_modify_stack.h
@@ -59,7 +59,7 @@ namespace dynstack
 			{
 				auto tmp = TStack::back();
 				
-				TFunc(*tmp);
+				TFunc(tmp);
 
 				return tmp;
 			}
@@ -68,7 +68,7 @@ namespace dynstack
 			{
 				auto tmp = TStack::pop_back();
 
-				TFunc(*tmp);
+				TFunc(tmp);
 
 				return tmp;
 			}


### PR DESCRIPTION
I have been trying to use the out_modify_stack. 
My `dynstack_setup.h` looks like this:

```
#pragma once

#include "basic/particle_deduction.h"
typedef DeductedParticleType Particle;

#include "dynstack/stack/storage/lifo_stack.h"
#include "dynstack/stack/wrapper/out_modify_stack.h"

#include <memory>
#include <vector>
#include <list>
#include <string>

void modify(DeductedParticleType& p)
{
    //do stuff with p
}

typedef dynstack::wrapper::OutputModifyStack<dynstack::storage::LIFO_Stack<DeductedParticleType>, modify> stacktype;

auto dynstack_setup(std::vector<long> sizes, std::vector< std::list<std::string> > arguments ) -> decltype(std::unique_ptr< stacktype >())
{
    if(sizes.size() != 1)
        {
                std::cerr << "You need to define the size of a single stack with DYNSTACK N in the input card" << std::endl;
        std::cerr << "You provided " << sizes.size() << " Arguments" << std::endl;
        
                exit(-1);
        }
    const int stackSize = sizes[0];

    auto stack = std::make_unique< stacktype >(stackSize);

    std::cout << "(dyn) Create default stack" << std::endl;

    return std::move(stack);
}

inline void reset(){}

inline void close() {}

```

Trying to compile this code (I use the dynstack implementation provided by the most recent release of corsika7, since I can't make it work in combination with the most recent version of this repository), I get the error:

```
./dynstack/stack/wrapper/out_modify_stack.h:71:40: error: invalid initialization of non-const reference of type 'DeductedParticleType&' {aka 'lib::data::ParticleData<0, 0>&'} from an rvalue of type 'lib::data::ParticleData<0, 0>*'
   71 |                                 TFunc(&tmp);
      |                                        ^~~
```

```
./dynstack/stack/wrapper/out_modify_stack.h:62:40: error: invalid initialization of non-const reference of type 'DeductedParticleType&' {aka 'lib::data::ParticleData<0, 0>&'} from an rvalue of type 'lib::data::ParticleData<0, 0>*'
   62 |                                 TFunc(&tmp);
      |                                        ^~~
```

This make sense for me, since we pass a reference to `TFunc`, so we can't use `*`.
With this change, the codes works for me.